### PR TITLE
Change example scrape interval in docs

### DIFF
--- a/docs/binary.mdx
+++ b/docs/binary.mdx
@@ -37,7 +37,7 @@ debug_info:
 
 scrape_configs:
   - job_name: "default"
-    scrape_interval: "1s"
+    scrape_interval: "2s"
     static_configs:
       - targets: ["127.0.0.1:7070"]
 ```


### PR DESCRIPTION
This PR changes the `scrape_interval` in the `docs/binary` example which don’t work out of the box. If I configure the interval to be `1s` I get an error with message “process_cpu scrape_timeout must be at least 2 seconds in default”. Changing the `parca.yaml` file as suggested fixes the problem.

Of course feel free to reject this PR or provide a better suggestion, I’m very new to parca 😄 